### PR TITLE
Utilize $OMV_MOUNT_DIR

### DIFF
--- a/usr/share/openmediavault/mkconf/backup
+++ b/usr/share/openmediavault/mkconf/backup
@@ -32,6 +32,7 @@ if [ "${sfref}" != "" ]; then
         --exclude=/run \
         --exclude=/mnt \
         --exclude=/media \
+        --exclude=${OMV_MOUNT_DIR:-/media} \
         --exclude=/lost+found \
         --exclude=/export \
         --exclude=/home/ftp \


### PR DESCRIPTION
In OMV3 the value of the variable OMV_MOUNT_DIR has been changed to /srv. (It was /media in OMV2.) Backup plugin needs to exclude that dir to avoid endless backup.