### PR TITLE
Add support for borgbackup

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Package: openmediavault-backup
 Architecture: all
 Depends: fsarchiver,
          openmediavault (>=4.1.5),
+         borgbackup,
          rsync
 Description: backup plugin for OpenMediaVault.
  This plugin will backup the entire OpenMediaVault

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -132,6 +132,33 @@ case ${method} in
         fsarchiver archinfo ${password} "${backupDir}/${BACKUP_FILE_PREFIX}-${date}.fsa"
         ;;
 
+    borg)
+        echo "Using borgbackup..."
+        extra=$(omv_config_get "/config/system/backup/extraoptions")
+        passwd="$(omv_config_get "/config/system/backup/passwd")"
+        if [ -n "${passwd}" ]; then
+            echo "Encrypting archive..."
+            export BORG_PASSPHRASE="${passwd}"
+        fi
+        if [ ! -d "${backupDir}/borgbackup" ] ; then
+          # First run - init borg directory
+          if [ -n "${passwd}" ]; then
+            borg init -e repokey "${backupDir}/borgbackup"
+          else
+            borg init -e none "${backupDir}/borgbackup"
+          fi
+        fi
+        borg create --stats "${backupDir}/borgbackup::${BACKUP_FILE_PREFIX}-${date}" / \
+          -x --exclude-caches \
+          -e "/dev" -e "/proc" -e "/sys" -e "/tmp" -e "/run" -e "/mnt" \
+          -e "/media" -e "/lost+found" -e "/export" -e "/home/ftp" -e "/srv" ${extra}
+        keep=$(omv_config_get "/config/system/backup/keep")
+        if [[ ${keep} -gt 0 ]]; then
+          purgeOld
+          borg prune "${backupDir}/borgbackup" --keep-daily "${keep}"
+        fi
+        ;;
+
     rsync)
         echo "Using rsync..."
         extra=$(omv_config_get "/config/system/backup/extraoptions")

--- a/usr/share/openmediavault/datamodels/conf.system.backup.json
+++ b/usr/share/openmediavault/datamodels/conf.system.backup.json
@@ -19,7 +19,7 @@
 		},
 		"method": {
 			"type": "string",
-			"enum": ["rsync","fsarchiver","dd"]
+			"enum": ["rsync","fsarchiver","borg","dd"]
 		},
 		"root": {
 			"type": "string"

--- a/usr/share/openmediavault/datamodels/rpc.backup.json
+++ b/usr/share/openmediavault/datamodels/rpc.backup.json
@@ -17,7 +17,7 @@
 			},
 			"method": {
 				"type": "string",
-				"enum": ["rsync","fsarchiver","dd"],
+				"enum": ["rsync","fsarchiver","borg","dd"],
 				"required": true
 			},
 			"root": {

--- a/usr/share/openmediavault/locale/openmediavault-backup.pot
+++ b/usr/share/openmediavault/locale/openmediavault-backup.pot
@@ -29,7 +29,7 @@ msgstr ""
 msgid "For advanced users only - Do not use unless exact root device is known."
 msgstr ""
 
-msgid "If a password is specified, fsarchiver will be encrypted. Must be between 6 and 64 characters."
+msgid "If a password is specified, backup will be encrypted. Must be between 6 and 64 characters."
 msgstr ""
 
 msgid "Keep"
@@ -71,7 +71,10 @@ msgstr ""
 msgid "fsarchiver"
 msgstr ""
 
-msgid "fsarchiver - use fsarchiver to clone all partitions to an archive file"
+msgid "borgbackup"
+msgstr ""
+
+msgid "borgbackup - use borgbackup to backup system to an archive file"
 msgstr ""
 
 msgid "rsync"

--- a/var/www/openmediavault/js/omv/module/admin/system/backup/SystemBackup.js
+++ b/var/www/openmediavault/js/omv/module/admin/system/backup/SystemBackup.js
@@ -75,7 +75,7 @@ Ext.define('OMV.module.admin.system.backup.SystemBackup', {
         },{
             conditions: [{
                 name: 'method',
-                value: 'fsarchiver'
+                value: ['fsarchiver','borg']
             }],
             name: ['passwd'],
             properties: ['show', 'submitValue']
@@ -131,6 +131,7 @@ Ext.define('OMV.module.admin.system.backup.SystemBackup', {
                 store: [
                     [ 'dd', _('dd') ],
                     [ 'fsarchiver', _('fsarchiver') ],
+                    [ 'borg', _('borgbackup') ],
                     [ 'rsync', _('rsync') ]
                 ],
                 editable: false,
@@ -141,6 +142,8 @@ Ext.define('OMV.module.admin.system.backup.SystemBackup', {
                     text: _('dd - use dd to clone the entire drive to a compressed image file.') +
                             '<br />' +
                           _('fsarchiver - use fsarchiver to clone all partitions to an archive file') +
+                            '<br />' +
+                          _('borgbackup - use borgbackup to backup system to an archive file') +
                             '<br />' +
                           _('rsync - use rsync to sync files to destination directory')
                 }]
@@ -188,7 +191,7 @@ Ext.define('OMV.module.admin.system.backup.SystemBackup', {
                 allowBlank: true,
                 plugins: [{
                     ptype: 'fieldinfo',
-                    text: _('If a password is specified, fsarchiver will be encrypted. Must be between 6 and 64 characters.')
+                    text: _('If a password is specified, backup will be encrypted. Must be between 6 and 64 characters.')
                 }]
             }]
         }];


### PR DESCRIPTION
As a [borgbackup](https://www.borgbackup.org/) lover, I just had to add support for it ;-) borg backup features a powerful deduplication mechanism, which allows keeping several backup generations without wasting a lot of disk space.

The parameters are similar to fsarchiver, the file exclusion list is inspired by the rsync parameters.