### PR TITLE
Support Backup of GPT

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -84,9 +84,13 @@ fdisk -l ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fdisk"
 blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
 
+# calculate partition table size to accommodate GPT and MBR.
+num_parts=$(parted -m ${root} print | tail -n1 | cut -b1)
+grubparts_bs_calc=$(((128 * ${num_parts}) + 1024))
+
 # save partition table and mbr
 dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=512 count=1
+dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs="${grubparts_bs_calc}" count=1
 
 # check for /boot partition
 bootpart=$(grep -w /boot /proc/mounts | awk '{ print $1 }')

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -85,8 +85,14 @@ blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
 
 # calculate partition table size to accommodate GPT and MBR.
-num_parts=$(parted -m ${root} print | tail -n1 | cut -b1)
-grubparts_bs_calc=$(((128 * ${num_parts}) + 1024))
+part_type=$(blkid -p ${root} | cut -d \" -f4)
+if [ "${part_type}" = "gpt" ]; then
+    num_parts=$(parted -m ${root} print | tail -n1 | cut -b1)
+    grubparts_bs_calc=$(((128 * ${num_parts}) + 1024))
+else
+    grubparts_bs_calc=512
+fi
+
 
 # save partition table and mbr
 dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -90,7 +90,7 @@ grubparts_bs_calc=$(((128 * ${num_parts}) + 1024))
 
 # save partition table and mbr
 dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs="${grubparts_bs_calc}" count=1
+dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
 
 # check for /boot partition
 bootpart=$(grep -w /boot /proc/mounts | awk '{ print $1 }')


### PR DESCRIPTION
Script is hardcoded for a block size of 512 bytes for dd, which works for mbr partition tables, but for gpt, this needs to be calculated based on number of partitions and is always larger than 512, resulting in incomplete partitional table upon restore to a new/replacement disk. I've added the check for gpt and also the calculation for block size and replaced the dd backup command to include the calculated value. I have tested this change on both mbr and gpt.