### PR TITLE
Improve script logging

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -39,8 +39,7 @@ purgeOld()
         if [ $? -eq 0 ]; then
             _log "Purging done."
         else
-            _log "ERROR: Purge failed!"
-            exit 1
+            _log "WARNING: Purge failed!"
         fi
     else
         _log "Purging disabled."
@@ -114,24 +113,21 @@ fdisk -l ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fdisk"
 if [ $? -eq 0 ]; then
     _log "Successfully saved fdisk output for ${root}"
 else
-    _log "ERROR: Save of fdisk output for ${root} failed!"
-    exit 1
+    _log "WARNING: Save of fdisk output for ${root} failed!"
 fi
 _log "Save blkid output"
 blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
 if [ $? -eq 0 ]; then
     _log "Successfully saved blkid output"
 else
-    _log "ERROR: Save of blkid output failed!"
-    exit 1
+    _log "WARNING: Save of blkid output failed!"
 fi
 _log "Save package list"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
 if [ $? -eq 0 ]; then
     _log "Successfully saved package list"
 else
-    _log "ERROR: Save of package list failed!"
-    exit 1
+    _log "WARNING: Save of package list failed!"
 fi
 
 # calculate partition table size to accommodate GPT and MBR.
@@ -153,8 +149,7 @@ if [ "${part_type}" = "gpt" ]; then
         if [ $? -eq 0 ]; then
             _log "Successfully backuped ESP partition"
         else
-            _log "ERROR: Backup of ESP partition failed!"
-            exit 1
+            _log "WARNING: Backup of ESP partition failed!"
         fi
     else
       _log "ESP partition '${esppart}' not found."
@@ -170,16 +165,14 @@ fi
     if [ $? -eq 0 ]; then
         _log "Successfully saved MBR"
     else
-        _log "ERROR: Save of MBR failed!"
-        exit 1
+        _log "WARNING: Save of MBR failed!"
     fi
     _log "Save mbr and partition table"
     dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
     if [ $? -eq 0 ]; then
         _log "Successfully saved MBR and partition table"
     else
-        _log "ERROR: Save of MBR and partition table failed!"
-        exit 1
+        _log "WARNING: Save of MBR and partition table failed!"
     fi
 
 # check for /boot partition
@@ -199,8 +192,7 @@ if [ -f "/usr/lib/u-boot/platform_install.sh" ]; then
         if [ $? -eq 0 ]; then
             _log "Successfully backuped u-boot"
         else
-            _log "ERROR: Backup of u-boot failed!"
-            exit 1
+            _log "WARNING: Backup of u-boot failed!"
         fi
     fi
 fi

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -10,7 +10,6 @@
 #
 # version: 1.1.0
 #
-set -e
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions
@@ -37,7 +36,12 @@ purgeOld()
     if [[ ${keep} -gt 0 ]]; then
         _log "Purging old files..."
         find "${backupDir}" -maxdepth ${OMV_BACKUP_MAX_DEPTH} -type f -mtime +${keep} -name "${OMV_BACKUP_FILE_PREFIX}*" -delete
-        _log "Purging done."
+        if [ $? -eq 0 ]; then
+            _log "Purging done."
+        else
+            _log "ERROR: Purge failed!"
+            exit 1
+        fi
     else
         _log "Purging disabled."
     fi
@@ -107,10 +111,28 @@ fi
 # save helpful information
 _log "Save fdisk output for ${root}"
 fdisk -l ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fdisk"
+if [ $? -eq 0 ]; then
+    _log "Successfully saved fdisk output for ${root}"
+else
+    _log "ERROR: Save of fdisk output for ${root} failed!"
+    exit 1
+fi
 _log "Save blkid output"
 blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
+if [ $? -eq 0 ]; then
+    _log "Successfully saved blkid output"
+else
+    _log "ERROR: Save of blkid output failed!"
+    exit 1
+fi
 _log "Save package list"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
+if [ $? -eq 0 ]; then
+    _log "Successfully saved package list"
+else
+    _log "ERROR: Save of package list failed!"
+    exit 1
+fi
 
 # calculate partition table size to accommodate GPT and MBR.
 part_type=$(blkid -p ${root} | cut -d \" -f4)
@@ -126,8 +148,14 @@ if [ "${part_type}" = "gpt" ]; then
     esppart="${root}${partletter}${esp}"
     _log "ESP partition :: ${esppart}"
     if [ -e "${esppart}" ]; then
-      _log "Backup ESP partition"
-      dd if=${esppart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.gz"
+        _log "Backup ESP partition"
+        dd if=${esppart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.gz"
+        if [ $? -eq 0 ]; then
+            _log "Successfully backuped ESP partition"
+        else
+            _log "ERROR: Backup of ESP partition failed!"
+            exit 1
+        fi
     else
       _log "ESP partition '${esppart}' not found."
     fi
@@ -137,10 +165,22 @@ fi
 
 
 # save partition table and mbr
-_log "Save mbr"
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
-_log "Save mbr and partition table"
-dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
+    _log "Save mbr"
+    dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
+    if [ $? -eq 0 ]; then
+        _log "Successfully saved MBR"
+    else
+        _log "ERROR: Save of MBR failed!"
+        exit 1
+    fi
+    _log "Save mbr and partition table"
+    dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
+    if [ $? -eq 0 ]; then
+        _log "Successfully saved MBR and partition table"
+    else
+        _log "ERROR: Save of MBR and partition table failed!"
+        exit 1
+    fi
 
 # check for /boot partition
 bootpart=$(awk '$2 == "/boot" { print $1 }' /proc/mounts)
@@ -156,6 +196,12 @@ if [ -f "/usr/lib/u-boot/platform_install.sh" ]; then
     if [ -d "${DIR}" ]; then
         _log "Backup u-boot"
         tar cjf "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_u-boot.tar.bz" ${DIR}/*
+        if [ $? -eq 0 ]; then
+            _log "Successfully backuped u-boot"
+        else
+            _log "ERROR: Backup of u-boot failed!"
+            exit 1
+        fi
     fi
 fi
 
@@ -168,7 +214,8 @@ case ${method} in
         _log "dd exit code = ${status[0]}"
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
-            _log "dd backup failed!"
+            _log "ERROR: dd backup failed!"
+            exit 1
         else
             _log "dd backup complete."
         fi
@@ -176,7 +223,12 @@ case ${method} in
         if [ -n "${bootpart}" ]; then
             _log "Starting dd backup of boot partition..."
             dd if=${bootpart} bs=1M conv=sync,noerror status=progress | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_boot.dd.gz"
-            _log "dd backup of boot partition complete."
+            if [ $? -eq 0 ]; then
+                _log "dd backup of boot partition complete."
+            else
+                _log "ERROR: dd backup of boot partition failed!"
+                exit 1
+            fi
         fi
         sync
         touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"-${date}*.dd.gz
@@ -190,7 +242,8 @@ case ${method} in
         _log "dd exit code = ${status[0]}"
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
-            _log "dd full disk backup failed!"
+            _log "ERROR: dd full disk backup failed!"
+            exit 1
         else
             _log "dd full disk backup complete."
         fi
@@ -211,7 +264,8 @@ case ${method} in
         fi
         fsarchiver savefs ${password}-o "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fsa" ${devicefile} ${bootpart} -v -A ${extra}
         if [ $? -ne 0 ]; then
-            _log "FSArchiver backup failed!"
+            _log "ERROR: FSArchiver backup failed!"
+            exit 1
         else
             _log "FSArchiver backup complete."
         fi
@@ -243,7 +297,8 @@ case ${method} in
           -e "/dev" -e "/proc" -e "/sys" -e "/tmp" -e "/run" -e "/mnt" \
           -e "/media" -e "/lost+found" -e "/export" -e "/home/ftp" -e "/srv" ${extra}
         if [ $? -ne 0 ]; then
-            _log "borgbackup create failed!"
+            _log "ERROR: borgbackup create failed!"
+            exit 1
         else
             _log "borgbackup create complete."
         fi
@@ -252,7 +307,12 @@ case ${method} in
           purgeOld
           _log "Starting borgbackup prune..."
           borg prune "${backupDir}/borgbackup" --keep-daily "${keep}"
-          _log "borgbackup prune complete."
+          if [ $? -ne 0 ]; then
+              _log "ERROR: borgbackup prune failed!"
+            exit 1	
+          else
+            _log "borgbackup prune complete."
+          fi
         fi
         ;;
 
@@ -274,7 +334,8 @@ case ${method} in
             --exclude=/home/ftp \
             --exclude=/srv ${extra}
         if [ $? -ne 0 ]; then
-            _log "rsync backup failed!"
+            _log "ERROR: rsync backup failed!"
+            exit 1
         else
             _log "rsync backup complete."
         fi

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -39,10 +39,10 @@ _log_warning() # Level for recoverable errors.
     _log_export "$(omv_warning "${msg}")"
 }
 
-_log_error() # Level for unrecoverable errors.
+_log_error() # Level for unrecoverable errors that would be write to stderr an to the logfile.
 {
-    msg="$(omv_error "${1}" 2>&1)"
-    _log_export "${msg}"
+    msg=${1}
+    echo "[$(date +'%Y-%m-%d %H:%M:%S%z')] [backup] $(omv_error "${msg}" 2>&1)" > >(tee -a ${logFile} >&2)
 }
 
 purgeOld()

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -62,12 +62,12 @@ touch /var/cache/openmediavault/archives/Packages
 # Get the shared folder reference and path
 sfref=$(omv_config_get "/config/system/backup/sharedfolderref")
 if ! omv_isuuid "${sfref}"; then
-    _log "No backup volume set.  Please choose a backup volume."
+    _log "ERROR: No backup volume set.  Please choose a backup volume."
     exit 10
 fi
 sfpath="$(omv_get_sharedfolder_path "${sfref}")"
 if [ ! -d "${sfpath}" ]; then
-    _log "Shared folder directory does not exist.  Exiting..."
+    _log "ERROR: Shared folder directory does not exist.  Exiting..."
     exit 11
 fi
 
@@ -90,7 +90,7 @@ if [ "${devicefile}" = "/dev/root" ]; then
 fi
 
 if [ "${devicefile}" = "/dev/root" ] || [ -z "${devicefile}" ]; then
-    _log "Could not determine root device file. Please specify in the root device textbox. Exiting..."
+    _log "ERROR: Could not determine root device file. Please specify in the root device textbox. Exiting..."
     exit 12
 fi
 
@@ -104,7 +104,7 @@ fi
 _log "Root drive: ${root}"
 
 if [ -z "${root}" ]; then
-    _log "Could not determine root device.  Exiting..."
+    _log "ERROR: Could not determine root device.  Exiting..."
     exit 13
 fi
 

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -8,7 +8,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# version: 1.1.0
+# version: 1.1.1
 #
 
 . /etc/default/openmediavault

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -22,10 +22,27 @@ OMV_BACKUP_MAX_DEPTH=${OMV_BACKUP_MAX_DEPTH:-"1"}
 logDir="/var/log/"
 logFile="${logDir}/omv-backup.log"
 
+_log_export() # Shim to write messages to stdout and to the logfile.
+{
+    echo "[$(date +'%Y-%m-%d %H:%M:%S%z')] [backup] ${msg}" | tee -a ${logFile} >&2
+}
+
 _log()
 {
-  msg=${1}
-  echo "[$(date +'%Y-%m-%d %H:%M:%S%z')] [backup] ${msg}" | tee -a ${logFile} >&2
+    msg=${1}
+    _log_export "$(omv_log "${msg}")"
+}
+
+_log_warning() # Level for recoverable errors.
+{
+    msg=${1}
+    _log_export "$(omv_warning "${msg}")"
+}
+
+_log_error() # Level for unrecoverable errors.
+{
+    msg="$(omv_error "${1}" 2>&1)"
+    _log_export "${msg}"
 }
 
 purgeOld()
@@ -39,7 +56,7 @@ purgeOld()
         if [ $? -eq 0 ]; then
             _log "Purging done."
         else
-            _log "WARNING: Purge failed!"
+            _log_warning "Purge failed!"
         fi
     else
         _log "Purging disabled."
@@ -61,12 +78,12 @@ touch /var/cache/openmediavault/archives/Packages
 # Get the shared folder reference and path
 sfref=$(omv_config_get "/config/system/backup/sharedfolderref")
 if ! omv_isuuid "${sfref}"; then
-    _log "ERROR: No backup volume set.  Please choose a backup volume."
+    _log_error "No backup volume set.  Please choose a backup volume."
     exit 10
 fi
 sfpath="$(omv_get_sharedfolder_path "${sfref}")"
 if [ ! -d "${sfpath}" ]; then
-    _log "ERROR: Shared folder directory does not exist.  Exiting..."
+    _log_error "Shared folder directory does not exist.  Exiting..."
     exit 11
 fi
 
@@ -89,7 +106,7 @@ if [ "${devicefile}" = "/dev/root" ]; then
 fi
 
 if [ "${devicefile}" = "/dev/root" ] || [ -z "${devicefile}" ]; then
-    _log "ERROR: Could not determine root device file. Please specify in the root device textbox. Exiting..."
+    _log_error "Could not determine root device file. Please specify in the root device textbox. Exiting..."
     exit 12
 fi
 
@@ -103,7 +120,7 @@ fi
 _log "Root drive: ${root}"
 
 if [ -z "${root}" ]; then
-    _log "ERROR: Could not determine root device.  Exiting..."
+    _log_error "Could not determine root device.  Exiting..."
     exit 13
 fi
 
@@ -113,21 +130,21 @@ fdisk -l ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fdisk"
 if [ $? -eq 0 ]; then
     _log "Successfully saved fdisk output for ${root}"
 else
-    _log "WARNING: Save of fdisk output for ${root} failed!"
+    _log_warning "Save of fdisk output for ${root} failed!"
 fi
 _log "Save blkid output"
 blkid > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.blkid"
 if [ $? -eq 0 ]; then
     _log "Successfully saved blkid output"
 else
-    _log "WARNING: Save of blkid output failed!"
+    _log_warning "Save of blkid output failed!"
 fi
 _log "Save package list"
 dpkg -l | grep openmediavault > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.packages"
 if [ $? -eq 0 ]; then
     _log "Successfully saved package list"
 else
-    _log "WARNING: Save of package list failed!"
+    _log_warning "Save of package list failed!"
 fi
 
 # calculate partition table size to accommodate GPT and MBR.
@@ -149,7 +166,7 @@ if [ "${part_type}" = "gpt" ]; then
         if [ $? -eq 0 ]; then
             _log "Successfully backuped ESP partition"
         else
-            _log "WARNING: Backup of ESP partition failed!"
+            _log_warning "Backup of ESP partition failed!"
         fi
     else
       _log "ESP partition '${esppart}' not found."
@@ -165,14 +182,14 @@ fi
     if [ $? -eq 0 ]; then
         _log "Successfully saved MBR"
     else
-        _log "WARNING: Save of MBR failed!"
+        _log_warning "Save of MBR failed!"
     fi
     _log "Save mbr and partition table"
     dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
     if [ $? -eq 0 ]; then
         _log "Successfully saved MBR and partition table"
     else
-        _log "WARNING: Save of MBR and partition table failed!"
+        _log_warning "Save of MBR and partition table failed!"
     fi
 
 # check for /boot partition
@@ -192,7 +209,7 @@ if [ -f "/usr/lib/u-boot/platform_install.sh" ]; then
         if [ $? -eq 0 ]; then
             _log "Successfully backuped u-boot"
         else
-            _log "WARNING: Backup of u-boot failed!"
+            _log_warning "Backup of u-boot failed!"
         fi
     fi
 fi
@@ -206,7 +223,7 @@ case ${method} in
         _log "dd exit code = ${status[0]}"
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
-            _log "ERROR: dd backup failed!"
+            _log_error "dd backup failed!"
             exit 14
         else
             _log "dd backup complete."
@@ -218,7 +235,7 @@ case ${method} in
             if [ $? -eq 0 ]; then
                 _log "dd backup of boot partition complete."
             else
-                _log "ERROR: dd backup of boot partition failed!"
+                _log_error "dd backup of boot partition failed!"
                 exit 15
             fi
         fi
@@ -234,7 +251,7 @@ case ${method} in
         _log "dd exit code = ${status[0]}"
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
-            _log "ERROR: dd full disk backup failed!"
+            _log_error "dd full disk backup failed!"
             exit 16
         else
             _log "dd full disk backup complete."
@@ -256,7 +273,7 @@ case ${method} in
         fi
         fsarchiver savefs ${password}-o "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fsa" ${devicefile} ${bootpart} -v -A ${extra}
         if [ $? -ne 0 ]; then
-            _log "ERROR: FSArchiver backup failed!"
+            _log_error "FSArchiver backup failed!"
             exit 17
         else
             _log "FSArchiver backup complete."
@@ -289,7 +306,7 @@ case ${method} in
           -e "/dev" -e "/proc" -e "/sys" -e "/tmp" -e "/run" -e "/mnt" \
           -e "/media" -e "/lost+found" -e "/export" -e "/home/ftp" -e "/srv" ${extra}
         if [ $? -ne 0 ]; then
-            _log "ERROR: borgbackup create failed!"
+            _log_error "borgbackup create failed!"
             exit 18
         else
             _log "borgbackup create complete."
@@ -300,7 +317,7 @@ case ${method} in
           _log "Starting borgbackup prune..."
           borg prune "${backupDir}/borgbackup" --keep-daily "${keep}"
           if [ $? -ne 0 ]; then
-              _log "ERROR: borgbackup prune failed!"
+              _log_error "borgbackup prune failed!"
             exit 19
           else
             _log "borgbackup prune complete."
@@ -326,7 +343,7 @@ case ${method} in
             --exclude=/home/ftp \
             --exclude=/srv ${extra}
         if [ $? -ne 0 ]; then
-            _log "ERROR: rsync backup failed!"
+            _log_error "rsync backup failed!"
             exit 20
         else
             _log "rsync backup complete."

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -207,7 +207,7 @@ case ${method} in
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log "ERROR: dd backup failed!"
-            exit 1
+            exit 14
         else
             _log "dd backup complete."
         fi
@@ -219,7 +219,7 @@ case ${method} in
                 _log "dd backup of boot partition complete."
             else
                 _log "ERROR: dd backup of boot partition failed!"
-                exit 1
+                exit 15
             fi
         fi
         sync
@@ -235,7 +235,7 @@ case ${method} in
         _log "gzip exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log "ERROR: dd full disk backup failed!"
-            exit 1
+            exit 16
         else
             _log "dd full disk backup complete."
         fi
@@ -257,7 +257,7 @@ case ${method} in
         fsarchiver savefs ${password}-o "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.fsa" ${devicefile} ${bootpart} -v -A ${extra}
         if [ $? -ne 0 ]; then
             _log "ERROR: FSArchiver backup failed!"
-            exit 1
+            exit 17
         else
             _log "FSArchiver backup complete."
         fi
@@ -290,7 +290,7 @@ case ${method} in
           -e "/media" -e "/lost+found" -e "/export" -e "/home/ftp" -e "/srv" ${extra}
         if [ $? -ne 0 ]; then
             _log "ERROR: borgbackup create failed!"
-            exit 1
+            exit 18
         else
             _log "borgbackup create complete."
         fi
@@ -301,7 +301,7 @@ case ${method} in
           borg prune "${backupDir}/borgbackup" --keep-daily "${keep}"
           if [ $? -ne 0 ]; then
               _log "ERROR: borgbackup prune failed!"
-            exit 1	
+            exit 19
           else
             _log "borgbackup prune complete."
           fi
@@ -327,7 +327,7 @@ case ${method} in
             --exclude=/srv ${extra}
         if [ $? -ne 0 ]; then
             _log "ERROR: rsync backup failed!"
-            exit 1
+            exit 20
         else
             _log "rsync backup complete."
         fi


### PR DESCRIPTION
## What is the current behavior?

Issue Number: Fixes #44

## What is the new behavior?

Automatic stop on error have been removed, and manual check have been added at major steps.

This also add log on success on some steps previously ignored, and add an "ERROR:" tag at the start of each ... error message (who would have guessed?).

## Tasks
- [x] Make all errors code different. b7d9905
- [x] Add intermediate level (warning) who wouldn't stop the script. 3833f40
- [x] Integrate `omv_log`, `omv_warning` and `omv_error`. 87b0174
- [x] Write error at `stderr` to be able to have only error if `stdout` is sent to "/dev/null" (example, to send mail only on error). d4c626e
- [ ] ???
- [ ] Profit!