### PR TITLE
Fix License

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -5,7 +5,7 @@
 # Copyright (c) 2013-2023 OpenMediaVault Plugin Developers
 #
 # This file is licensed under the terms of the GNU General Public
-# License version 2. This program is licensed "as is" without any
+# License version 3. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
 # version: 1.1.0


### PR DESCRIPTION
Issue Number: #46

## Change

- Change the license of omv-backup to GPLv3.

Obviously, if this PR is considered to have an interest, this change would need to be especially approve by the others authors.

## Other information

As specified in the bug report, wouldn't it be better to add a LICENSE file to specify that the whole project is under GPLv3 by default instead of doing it file by file?

Signed-off-by: clexanis <clexanis@users.noreply.github.com>