### PR TITLE
add: include sfdisk dump in backup

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -195,7 +195,7 @@ fi
 # Save partition table using sfdisk
 # In this thread https://forum.openmediavault.org/index.php?thread/46590-is-the-backup-plugin-s-grub-backup-broken/
 # It was discovered that USB devices sometimes do not do well with dd based partition tables restore. Out of 3 devices tested, 2 were found to
-# not be able to do a proper restore using dd. Hoeever, sfdisk based backup is still able to perfom a restore in this situation.
+# not be able to do a proper restore using dd. However, sfdisk based backup is still able to perform a restore in this situation.
 _log "Save partitions using sfdisk"
 sfdisk -d ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.sfdisk"
 if [ $? -eq 0 ]; then

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -193,9 +193,6 @@ else
 fi
 
 # Save partition table using sfdisk
-# In this thread https://forum.openmediavault.org/index.php?thread/46590-is-the-backup-plugin-s-grub-backup-broken/
-# It was discovered that USB devices sometimes do not do well with dd based partition tables restore. Out of 3 devices tested, 2 were found to
-# not be able to do a proper restore using dd. However, sfdisk based backup is still able to perform a restore in this situation.
 _log "Save partitions using sfdisk"
 sfdisk -d ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.sfdisk"
 if [ $? -eq 0 ]; then

--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -177,20 +177,32 @@ fi
 
 
 # save partition table and mbr
-    _log "Save mbr"
-    dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
-    if [ $? -eq 0 ]; then
-        _log "Successfully saved MBR"
-    else
-        _log_warning "Save of MBR failed!"
-    fi
-    _log "Save mbr and partition table"
-    dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
-    if [ $? -eq 0 ]; then
-        _log "Successfully saved MBR and partition table"
-    else
-        _log_warning "Save of MBR and partition table failed!"
-    fi
+_log "Save mbr"
+dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grub" bs=446 count=1
+if [ $? -eq 0 ]; then
+    _log "Successfully saved MBR"
+else
+    _log_warning "Save of MBR failed!"
+fi
+_log "Save mbr and partition table"
+dd if=${root} of="${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.grubparts" bs=${grubparts_bs_calc} count=1
+if [ $? -eq 0 ]; then
+    _log "Successfully saved MBR and partition table"
+else
+    _log_warning "Save of MBR and partition table failed!"
+fi
+
+# Save partition table using sfdisk
+# In this thread https://forum.openmediavault.org/index.php?thread/46590-is-the-backup-plugin-s-grub-backup-broken/
+# It was discovered that USB devices sometimes do not do well with dd based partition tables restore. Out of 3 devices tested, 2 were found to
+# not be able to do a proper restore using dd. Hoeever, sfdisk based backup is still able to perfom a restore in this situation.
+_log "Save partitions using sfdisk"
+sfdisk -d ${root} > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.sfdisk"
+if [ $? -eq 0 ]; then
+    _log "Successfully saved partition table using sfdisk"
+else
+    _log_warning "Save of sfdisk partition table failed"
+fi
 
 # check for /boot partition
 bootpart=$(awk '$2 == "/boot" { print $1 }' /proc/mounts)


### PR DESCRIPTION
- inlcude sfdisk based dump in backup files
- fix alignment of a block of code

Why sfdisk when we already have dd ?
In this thread https://forum.openmediavault.org/index.php?thread/46590-is-the-backup-plugin-s-grub-backup-broken/
It was discovered that USB devices sometimes do not do well with dd based partition tables restore. Out of 3 devices tested, 2 were found to not be able to do a proper restore using dd. However, sfdisk based backup is still able to perform a restore in this situation.