### PR TITLE
replace gzip with zstd

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -175,7 +175,7 @@ if [ "${part_type}" = "gpt" ]; then
                 sp=" status=progress"
             fi
             _log "Backup ESP partition"
-            dd if=${esppart} bs=1M conv=sync,noerror${sp} | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.gz"
+            dd if=${esppart} bs=1M conv=sync,noerror${sp} | zstd -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.espdd.zst"
             if [ $? -eq 0 ]; then
                 _log "Successfully backuped ESP partition"
             else
@@ -246,10 +246,10 @@ case ${method} in
             sp=" status=progress"
         fi
         _log "Starting dd backup..."
-        dd if=${devicefile} bs=1M conv=sync,noerror${sp} | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.dd.gz"
+        dd if=${devicefile} bs=1M conv=sync,noerror${sp} | zstd -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.dd.zst"
         status=( "${PIPESTATUS[@]}" )
         _log "dd exit code = ${status[0]}"
-        _log "gzip exit code = ${status[1]}"
+        _log "zstd exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log_error "dd backup failed!"
             exit 14
@@ -259,7 +259,7 @@ case ${method} in
         sync
         if [ -n "${bootpart}" ]; then
             _log "Starting dd backup of boot partition..."
-            dd if=${bootpart} bs=1M conv=sync,noerror${sp} | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_boot.dd.gz"
+            dd if=${bootpart} bs=1M conv=sync,noerror${sp} | zstd -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}_boot.dd.zst"
             if [ $? -eq 0 ]; then
                 _log "dd backup of boot partition complete."
             else
@@ -268,7 +268,7 @@ case ${method} in
             fi
         fi
         sync
-        touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"-${date}*.dd.gz
+        touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"-${date}*.dd.zst
         purgeOld
         ;;
 
@@ -279,10 +279,10 @@ case ${method} in
             sp=" status=progress"
         fi
         _log "Starting dd full disk..."
-        dd if=${root} bs=1M conv=sync,noerror${sp} | gzip -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.ddfull.gz"
+        dd if=${root} bs=1M conv=sync,noerror${sp} | zstd -c > "${backupDir}/${OMV_BACKUP_FILE_PREFIX}-${date}.ddfull.zst"
         status=( "${PIPESTATUS[@]}" )
         _log "dd exit code = ${status[0]}"
-        _log "gzip exit code = ${status[1]}"
+        _log "zstd exit code = ${status[1]}"
         if [[ ${status[0]} -gt 0 ]] || [[ ${status[1]} -gt 0 ]]; then
             _log_error "dd full disk backup failed!"
             exit 16
@@ -291,7 +291,7 @@ case ${method} in
         fi
         sync
         sync
-        touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"*-${date}.ddfull.gz
+        touch "${backupDir}/${OMV_BACKUP_FILE_PREFIX}"*-${date}.ddfull.zst
         purgeOld
         ;;
 


### PR DESCRIPTION
Hi

I updated the script with just zstd instead of gzip:
It's almost 4x faster on my machine (j4105) and the archive is smaller

gzip:
40021000192 bytes (40 GB, 37 GiB) copied, 665.096 s, 60.2 MB/s
final file size: 1,32 Gb

zstd:
40021000192 bytes (40 GB, 37 GiB) copied, 181.178 s, 221 MB/s
final file size: 1,16 Gb

