### PR TITLE
Fix ESP partition name for mmcblk.

### DIFF
--- a/usr/sbin/omv-backup
+++ b/usr/sbin/omv-backup
@@ -184,7 +184,7 @@ if [ "${part_type}" = "gpt" ]; then
     _log "ESP partition not found."
   else
     partletter=""
-    if [[ ${root} =~ nvme ]]; then
+    if [[ ${root} =~ nvme ]] || [[ ${root} =~ mmcblk ]]; then
       partletter="p"
     fi
     esppart="${root}${partletter}${esp}"


### PR DESCRIPTION
The correct device file name should be like `/dev/mmcblk0p1` with a `p`, not `/dev/mmcblk01`.

I'm running my OMV on an SD card and the dev names are named in a similar fashion to `nvme`, with numbers instead of letters. Without this fix, it tries to back up `/dev/mmcblk01` which does not exist, and logs `"ESP partition '/dev/mmcblk01' not found."`.

I tested this fix live on my OMV6 installation. (Yeah, I know I need to upgrade to OMV7 but I need a working backup before I do that). I believe this should work for OMV7 as well. It's just a one letter fix and naming scheme stays the same across the Debian distro upgrade.